### PR TITLE
fix(windows): make clean script cross-platform using Node fs.rmSync

### DIFF
--- a/packages/ptb-builder/package.json
+++ b/packages/ptb-builder/package.json
@@ -13,7 +13,7 @@
   "types": "dist/types/index.d.ts",
   "style": "dist/index.css",
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "node -e \"import('node:fs').then(fs=>fs.rmSync('dist',{force:true,recursive:true}))\"",
     "build": "npm run clean && rollup -c",
     "lint": "npm run lint --prefix ../..",
     "format": "npm run format --prefix ../.."


### PR DESCRIPTION
This PR replaces the Unix-only `rm -rf dist` clean script with a cross-platform Node one-liner using `fs.rmSync` to better support Windows environments.

- packages/ptb-builder/package.json
  - "clean": "node -e \"import('node:fs').then(fs=>fs.rmSync('dist',{force:true,recursive:true}))\""

Tested locally on Windows with Node 18+.

Thanks!